### PR TITLE
Fixed issue with taco spawn location and heroFallAnimation position.

### DIFF
--- a/SkaterBrad/GameScene.swift
+++ b/SkaterBrad/GameScene.swift
@@ -109,6 +109,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         swipeDownRecognizer.direction = UISwipeGestureRecognizerDirection.Down
         self.view?.addGestureRecognizer(swipeDownRecognizer)
         
+
         
       // self.addChild(obst2)
         
@@ -161,6 +162,9 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         self.hero.physicsBody?.contactTestBitMask = UInt32(self.heroCategory) | UInt32(self.groundCategory) | UInt32(self.obstacleCategory) | UInt32(self.contactCategory) | UInt32(self.scoreCategory)
         self.hero.physicsBody?.collisionBitMask = UInt32(self.groundCategory) | UInt32(self.obstacleCategory) | UInt32(self.contactCategory)
         self.addChild(hero)
+        
+
+        
         
         // Ground [Kevin/Tina]
         var ground = SKShapeNode(rectOfSize: CGSize(width: 400, height: self.roadSize!.height))
@@ -260,6 +264,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         if self.jumpTime >= 0.5 && self.jumpMode == true {
             self.hero.texture = self.bradJumpDownTexture
         }
+        
     }
     
     // MARK: - TOUCHES BEGAN
@@ -482,8 +487,8 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     func heroFallAnimation(completionHandler: () -> Void) {
         println("Fall animation")
         let fallAnimation = SKAction.animateWithTextures(self.bradFallTextures, timePerFrame: 0.1)
-        let moveUp = SKAction.moveTo(CGPoint(x: self.roadSize!.width * 0.6, y: self.frame.height / 2), duration: 0.5)
-        let moveDown = SKAction.moveTo(CGPoint(x: self.roadSize!.width * 0.8, y: self.roadSize!.height * 0.9), duration: 0.3)
+        let moveUp = SKAction.moveTo(CGPoint(x: self.frame.width * 0.6, y: self.frame.height / 2), duration: 0.5)
+        let moveDown = SKAction.moveTo(CGPoint(x: self.frame.width * 0.8, y: self.roadSize!.height * 0.9), duration: 0.3)
         let upDown = SKAction.sequence([moveUp, moveDown])
         
         self.jumpMode = false
@@ -692,7 +697,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
         //var randX = arc4random_uniform(100)
         let coin = SKSpriteNode(imageNamed: "Taco")
 
-        coin.position = CGPointMake(CGRectGetMaxX(self.frame) /*+ CGFloat(randX)*/, self.frame.size.height * (2 / 3))
+        coin.position = CGPointMake(CGRectGetMaxX(self.frame) /*+ CGFloat(randX)*/, self.roadSize!.height + self.hero.size.height * 3)
         coin.size = CGSize(width: 30, height: 30)
         
         coin.physicsBody = SKPhysicsBody(rectangleOfSize: CGSize(width: 1 , height: 1))


### PR DESCRIPTION
The taco now spawns relative to the hero's height. The heroFallAnimation is now based on the frame of the SKScene and not the size of the roadNode.
