### PR TITLE
Added speed increase dependent on score

### DIFF
--- a/SkaterBrad/GameScene.swift
+++ b/SkaterBrad/GameScene.swift
@@ -29,6 +29,7 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
     // Score [KP]
     var scoreTextLabel: SKLabelNode!
     var score = 0
+    var scoreLevelLimit = 50
     
     // High Score [KP]
     let highScoreText = SKLabelNode(fontNamed: "SkaterDudes")
@@ -209,6 +210,13 @@ class GameScene: SKScene, SKPhysicsContactDelegate {
             self.hero.position.x = self.frame.size.width * self.heroPositionX
         }
         
+        // Add speed increase as a function of score. [Vincent]
+        if self.score >= self.scoreLevelLimit {
+            self.backgroundSpeed += 5
+            self.roadSpeed += 5
+            self.self.scoreLevelLimit += 50
+            println("Level Increase")
+        }
         
         // Moving Background [Kevin/Tina]
         self.enumerateChildNodesWithName("background", usingBlock: { (node, stop) -> Void in


### PR DESCRIPTION
Added logic into the update function that checks what the current score is. If the score is over a scoreLevelLimit, the background speed and road speed increase by 5. The scoreLevelLimit increments by 50, so the player must score an additional 50 points to increase the speed again.
